### PR TITLE
Update dependencies

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -3,10 +3,10 @@
   :url "https://github.com/duct-framework/server.http.jetty"
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
-  :dependencies [[org.clojure/clojure "1.9.0-alpha17"]
-                 [duct/core "0.6.0"]
+  :dependencies [[org.clojure/clojure "1.10.1"]
+                 [duct/core "0.7.0"]
                  [duct/logger "0.1.1"]
-                 [integrant "0.6.1"]
-                 [ring/ring-jetty-adapter "1.6.2"]]
+                 [integrant "0.7.0"]
+                 [ring/ring-jetty-adapter "1.7.1"]]
   :profiles
-  {:dev {:dependencies [[clj-http "2.1.0"]]}})
+  {:dev {:dependencies [[clj-http "3.10.0"]]}})

--- a/project.clj
+++ b/project.clj
@@ -5,7 +5,7 @@
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :dependencies [[org.clojure/clojure "1.10.1"]
                  [duct/core "0.7.0"]
-                 [duct/logger "0.1.1"]
+                 [duct/logger "0.3.0"]
                  [integrant "0.7.0"]
                  [ring/ring-jetty-adapter "1.7.1"]]
   :profiles

--- a/test/duct/server/http/jetty_test.clj
+++ b/test/duct/server/http/jetty_test.clj
@@ -9,7 +9,7 @@
 
 (defrecord TestLogger [logs]
   logger/Logger
-  (-log [_ level ns-str file line event data]
+  (-log [_ level ns-str file line id event data]
     (swap! logs conj [event data])))
 
 (duct/load-hierarchy)


### PR DESCRIPTION
Update all dependencies to get newer versions of clojure, jetty, integrant, duct and clj-http.