### PR TITLE
Bump ring-jetty-adapter to 1.15.4 (Jetty 12.1.8) to address CVE-2026-2332

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -1,4 +1,4 @@
 {:deps {org.clojure/clojure {:mvn/version "1.12.3"}
         org.duct-framework/logger {:mvn/version "0.4.0"}
         integrant/integrant {:mvn/version "1.0.1"}
-        ring/ring-jetty-adapter {:mvn/version "1.15.3"}}}
+        ring/ring-jetty-adapter {:mvn/version "1.15.4"}}}

--- a/project.clj
+++ b/project.clj
@@ -6,6 +6,6 @@
   :dependencies [[org.clojure/clojure "1.12.3"]
                  [org.duct-framework/logger "0.4.0"]
                  [integrant "1.0.1"]
-                 [ring/ring-jetty-adapter "1.15.3"]]
+                 [ring/ring-jetty-adapter "1.15.4"]]
   :profiles
   {:dev {:dependencies [[clj-http "3.13.1"]]}})


### PR DESCRIPTION
### Summary

Bumps `ring/ring-jetty-adapter` from 1.15.3 to 1.15.4, which upgrades the
transitive Eclipse Jetty dependency from 12.1.0 to 12.1.8 — a version that
includes the fix for CVE-2026-2332.

### Why

CVE-2026-2332 is an HTTP request smuggling vulnerability in Jetty's HTTP/1.1
parser, caused by improper parsing of quoted-string chunk extensions in chunked
transfer encoding (CWE-444). For the 12.1.x line, versions up to and including
12.1.6 are affected, and it is fixed in 12.1.7 and later.

`server.http.jetty` currently depends on `ring/ring-jetty-adapter 1.15.3`, which
pulls in Jetty 12.1.0 — within the affected range. `ring/ring-jetty-adapter
1.15.4` depends on Jetty 12.1.8, which includes the fix.

Today, downstream Duct applications have to override Jetty in their own
dependency manifests (e.g. `:override-deps` in `deps.edn`) to pick up the fixed
parser. Bumping the adapter here lets every consumer of
`org.duct-framework/server.http.jetty` get the fixed Jetty by default, without
per-project overrides.

### Changes

- `deps.edn`: `ring/ring-jetty-adapter` 1.15.3 → 1.15.4
- `project.clj`: same version bump

### Testing

- [x] Existing test suite passes: `lein test`
      → `Ran 3 tests containing 22 assertions. 0 failures, 0 errors.`
      (this repo has no `:test` alias in `deps.edn`, so use `lein test`;
      `clj -M:test` does not work here)
- [x] Dependency tree shows the Jetty server modules (`org.eclipse.jetty*`) at 12.1.8
      (`lein deps :tree | grep -i jetty`)
- [x] A Duct app using `module.web` + `server.http.jetty` boots and serves basic
      HTTP requests on Jetty 12.1.8
      → Verified with a minimal `org.duct-framework/main` app
      (`module.web 0.13.4` + this branch's `server.http.jetty` via `:local/root`).
      `clojure -M:duct --main` boots, and `curl -i http://127.0.0.1:3000/` returns
      `HTTP/1.1 200 OK` with `Server: Jetty(12.1.8)`.

### References

- NVD: https://nvd.nist.gov/vuln/detail/CVE-2026-2332
- Jetty security advisory: https://jetty.org/security.html
- GitLab advisory (jetty-http): https://advisories.gitlab.com/maven/org.eclipse.jetty/jetty-http/CVE-2026-2332/
- ring-jetty-adapter 1.15.4 (Clojars): https://clojars.org/ring/ring-jetty-adapter/versions/1.15.4